### PR TITLE
Add link to regular expressions in tokens docs

### DIFF
--- a/src/3.0.0.md
+++ b/src/3.0.0.md
@@ -203,6 +203,10 @@ or
 The following example is _invalid_, because the tokens are not separated by (at least) a slash:<br/>
 
 	taffy:uri="/artist/{artistId}{artistName}"
+	
+It is possbile to use regular expressions to disambiguate paramaters between end points. See https://github.com/atuttle/Taffy/wiki/Custom-token-regular-expressions for details.
+
+If you are expecting a URI to end in something that could be mistaken for a MIME type hint (e.g. `/artist/byEmail/foo@bar.com`) then you must use a regular expression in the token (e.g. `/artist/byEmail/{email:.+}`) to prevent Taffy attempting to use the last part (.com) as a MIME type and returning a 404 error as you probably do not have a serilizer for 'com'.
 
 ##### Tokens
 


### PR DESCRIPTION
Add link to regular expressions in tokens docs and also note the work around for issues with (final?) parameters that contain a '.'.