### PR TITLE
added **Available in:** Taffy 3.1+ to OnTaffyRequestEnd() event handler docs…

### DIFF
--- a/src/3.1.0.md
+++ b/src/3.1.0.md
@@ -641,7 +641,8 @@ Here, if the user doesn't have the `datareader` role assigned, they'll get a 403
 
 #### onTaffyRequestEnd()
 
-Parameters:
+**Available in:** Taffy 3.1+<br/>
+**Parameters:**
 
 * **verb (string)** - The HTTP request verb provided by the client
 * **cfc (string)** - The CFC name (minus ".cfc") that handled the request. (Bean Name, if using an external bean factory.)


### PR DESCRIPTION
Very minor addition to **OnTaffyRequestEnd()** event handler docs - added this as I wasted an embarrassingly large amount of time yesterday wondering why all my nice logging changes that I'd made to the API I was updating running on 3.0.1 didn't generate an error - but didn't log anything either!